### PR TITLE
Update cart types

### DIFF
--- a/src/features/cart/context/CartProvider.tsx
+++ b/src/features/cart/context/CartProvider.tsx
@@ -16,6 +16,7 @@ const CartProvider = ({ children }: CartProviderProps) => {
 
     const cartContext: CartContextProps = {
         meals: state.meals,
+        totalItems: state.totalItems,
         totalPrice: state.totalPrice,
         addMeal,
         removeMeal,
@@ -30,68 +31,3 @@ const CartProvider = ({ children }: CartProviderProps) => {
 };
 
 export default CartProvider;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-// import { useReducer } from "react";
-// import CartContext from "./CartContext";
-
-// import cartReducer, { initialState } from "./cartReducer";
-// import { CartContextProps, CartMeal } from "../types";
-
-// type CartProviderProps = {
-//   children: React.ReactNode;
-// };
-
-// const CartProvider = ({ children }: CartProviderProps) => {
-//   const [state, dispatch] = useReducer(cartReducer, initialState);
-
-//   const addMeal = (meal: CartMeal) => dispatch({ type: "ADD_MEAL", payload: meal });
-//   const removeMeal = (id: string) => dispatch({ type: "REMOVE_MEAL", payload: id });
-//   const clearCart = () => dispatch({ type: "CLEAR_CART" });
-
-//   const cartContext: CartContextProps = {
-//     meals: state.meals,
-//     totalPrice: state.totalPrice,
-//     addMeal,
-//     removeMeal,
-//     clearCart,
-//   };
-
-//   return (
-//     <CartContext.Provider value={cartContext}>
-//         {children}
-//     </CartContext.Provider>
-//   );
-// };
-
-// export default CartProvider;

--- a/src/features/cart/context/cartReducer.ts
+++ b/src/features/cart/context/cartReducer.ts
@@ -1,10 +1,4 @@
-import { CartMeal } from "../types";
-
-type CartState = {
-    meals: CartMeal[];
-    totalItems: number;
-    totalPrice: number;
-};
+import { CartMeal, CartState } from "../types";
 
 export const initialState: CartState = {
     meals: [],

--- a/src/features/cart/types/index.ts
+++ b/src/features/cart/types/index.ts
@@ -2,9 +2,13 @@ import { Meal } from "../../../types";
 
 export type CartMeal = Meal & { quantity: number };
 
-export interface CartContextProps {
+export type CartState = {
     meals: CartMeal[];
+    totalItems: number;
     totalPrice: number;
+};
+
+export type CartContextProps = CartState & {
     addMeal: (meal: CartMeal) => void;
     removeMeal: (id: string) => void;
     clearCart: () => void;


### PR DESCRIPTION
Added "totalItems" to the CartContext. That piece of information will be used throughout the application and I don't want users to implement the logic in different places.

When added the new field, updated "CartState" type, however, when switching to the CartProvider, I realized Typescript was not complaining. That's when I realized "CartState" and "CartContextProps" although related, were completely separeted on their definitions.

Moved "CartState" to the types folder, and updated "CartContextProps" to extend from "CartState". When I perform this operation, Typescript immediately complained in the CartProvider as totalItems was missing.